### PR TITLE
Clarify that this retrieves global node ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Get Repository ID action
+# Get Repository Global Node ID action
 
-This action gets the ID of the specified GitHub repository.
+This action gets the [global node ID](https://docs.github.com/en/graphql/guides/using-global-node-ids) of the specified GitHub repository.
 
 It can be used in other actions, to make calls to the [GitHub GraphQL API](https://docs.github.com/en/graphql/overview/public-schema).
 
-Note that the ID provided by this action won't be the same as `$GITHUB_REPOSITORY_ID`.
+Note that the global node ID of a repository is not the same as its repository ID (i.e., [`GITHUB_REPOSITORY_ID`](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)).
 
 ## Inputs
 
@@ -20,12 +20,12 @@ GitHub token. Defaults `${{ github.token }}`.
 
 ### `repo-id`
 
-The ID of the specified repository.
+The global node ID of the specified repository.
 
 ## Example usage
 
 ```yaml
-- name: Get repo ID
+- name: Get global node ID
   id: get-repo-id
   uses: nvdaes/get-repository-id@v1
   with:


### PR DESCRIPTION
Global node ID is not repository ID.  Call it what it is.

<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
https://github.com/nvdaes/get-repository-id/issues/7
### Summary of the issue:
Docs refer to a repository's global node ID as "repo ID," which is something different.
### Description of how this pull request fixes the issue:
Revise language in README
### Testing performed:
n/a
### Known issues with pull request:
n/a
### Change log entry:
n/a